### PR TITLE
NF-545 Pass x-correlation-id, x-request-id and x-session-id to EIS/file transmission synchronous

### DIFF
--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -47,7 +47,7 @@ class AmendCaseConnector @Inject()(
       http.POST[EISAmendCaseRequest, EISAmendCaseResponse](
         url,
         request,
-        EISApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ MDTPTracingHeaders(hc)
+        eisApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ mdtpTracingHeaders(hc)
       )(
         implicitly[Writes[EISAmendCaseRequest]],
         readFromJsonSuccessOrFailure,

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -52,9 +52,7 @@ class AmendCaseConnector @Inject()(
         implicitly[Writes[EISAmendCaseRequest]],
         readFromJsonSuccessOrFailure,
         hc.copy(
-          authorization = None, // sent via EISApiHeaders
-          requestId = None, // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
-          sessionId = None // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+          authorization = None,
         ),
         implicitly[ExecutionContext]
       )

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -39,7 +39,7 @@ class AmendCaseConnector @Inject()(
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
-  val url = config.eisBaseUrl + config.eisAmendCaseApiPath
+  val url: String = config.eisBaseUrl + config.eisAmendCaseApiPath
 
   def submitAmendClaim(request: EISAmendCaseRequest, correlationId: String)(implicit hc: HeaderCarrier
   ): Future[EISAmendCaseResponse] = {
@@ -47,7 +47,7 @@ class AmendCaseConnector @Inject()(
       http.POST[EISAmendCaseRequest, EISAmendCaseResponse](
         url,
         request,
-        eisApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken)
+        EISApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ MDTPTracingHeaders(hc)
       )(
         implicitly[Writes[EISAmendCaseRequest]],
         readFromJsonSuccessOrFailure,

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -51,7 +51,11 @@ class AmendCaseConnector @Inject()(
       )(
         implicitly[Writes[EISAmendCaseRequest]],
         readFromJsonSuccessOrFailure,
-        hc.copy(authorization = None),
+        hc.copy(
+          authorization = None, // sent via EISApiHeaders
+          requestId = None, // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+          sessionId = None // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+        ),
         implicitly[ExecutionContext]
       )
     }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -51,9 +51,7 @@ class AmendCaseConnector @Inject()(
       )(
         implicitly[Writes[EISAmendCaseRequest]],
         readFromJsonSuccessOrFailure,
-        hc.copy(
-          authorization = None,
-        ),
+        hc.copy(authorization = None),
         implicitly[ExecutionContext]
       )
     }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
@@ -48,7 +48,7 @@ class CreateCaseConnector @Inject()(
       http.POST[EISCreateCaseRequest, EISCreateCaseResponse](
         url,
         request,
-        EISApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ MDTPTracingHeaders(hc)
+        eisApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ mdtpTracingHeaders(hc)
       )(
         implicitly[Writes[EISCreateCaseRequest]],
         readFromJsonSuccessOrFailure,

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
@@ -52,7 +52,11 @@ class CreateCaseConnector @Inject()(
       )(
         implicitly[Writes[EISCreateCaseRequest]],
         readFromJsonSuccessOrFailure,
-        hc.copy(authorization = None),
+        hc.copy(
+          authorization = None, // sent via EISApiHeaders
+          requestId = None, // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+          sessionId = None // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+        ),
         implicitly[ExecutionContext]
       )
     }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
@@ -52,9 +52,7 @@ class CreateCaseConnector @Inject()(
       )(
         implicitly[Writes[EISCreateCaseRequest]],
         readFromJsonSuccessOrFailure,
-        hc.copy(
-          authorization = None,
-        ),
+        hc.copy(authorization = None),
         implicitly[ExecutionContext]
       )
     }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
@@ -53,9 +53,7 @@ class CreateCaseConnector @Inject()(
         implicitly[Writes[EISCreateCaseRequest]],
         readFromJsonSuccessOrFailure,
         hc.copy(
-          authorization = None, // sent via EISApiHeaders
-          requestId = None, // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
-          sessionId = None // sent via MDTPTracingHeaders (None here prevents sending duplicate header to internal stubs)
+          authorization = None,
         ),
         implicitly[ExecutionContext]
       )

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/CreateCaseConnector.scala
@@ -39,7 +39,7 @@ class CreateCaseConnector @Inject()(
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
-  val url = config.eisBaseUrl + config.eisCreateCaseApiPath
+  val url: String = config.eisBaseUrl + config.eisCreateCaseApiPath
 
 
   def submitClaim(request: EISCreateCaseRequest, correlationId: String)(implicit hc: HeaderCarrier
@@ -48,7 +48,7 @@ class CreateCaseConnector @Inject()(
       http.POST[EISCreateCaseRequest, EISCreateCaseResponse](
         url,
         request,
-        eisApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken)
+        EISApiHeaders(correlationId, config.eisEnvironment, config.eisAuthorizationToken) ++ MDTPTracingHeaders(hc)
       )(
         implicitly[Writes[EISCreateCaseRequest]],
         readFromJsonSuccessOrFailure,

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
@@ -29,10 +29,11 @@ trait EISConnector {
     .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", ju.Locale.ENGLISH)
     .withZone(ZoneId.of("GMT"))
 
-  // TODO - simplify/make intent clearer!
   final def MDTPTracingHeaders(hc: HeaderCarrier): Seq[(String, String)] = {
-    hc.requestId.map(xRequestId => Seq(HeaderNames.xRequestId -> xRequestId.toString)).getOrElse(Seq.empty) ++
-    hc.sessionId.map(xSessionId => Seq(HeaderNames.xSessionId -> xSessionId.toString)).getOrElse(Seq.empty)
+    Seq(
+      hc.requestId.map(HeaderNames.xRequestId -> _.value),
+      hc.sessionId.map(HeaderNames.xSessionId -> _.value)
+    ).flatten
   }
 
   /** Headers required by the EIS API */

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.nationaldutyrepaymentcenter.connectors
 
+import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}
+
 import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 import java.{util => ju}
@@ -27,8 +29,14 @@ trait EISConnector {
     .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", ju.Locale.ENGLISH)
     .withZone(ZoneId.of("GMT"))
 
-  /** Headers required by the PEGA API */
-  final def eisApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
+  // TODO - simplify/make intent clearer!
+  final def MDTPTracingHeaders(hc: HeaderCarrier): Seq[(String, String)] = {
+    hc.requestId.map(xRequestId => Seq(HeaderNames.xRequestId -> xRequestId.toString)).getOrElse(Seq.empty) ++
+    hc.sessionId.map(xSessionId => Seq(HeaderNames.xSessionId -> xSessionId.toString)).getOrElse(Seq.empty)
+  }
+
+  /** Headers required by the EIS API */
+  final def EISApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
     Seq(
       "x-correlation-id"    -> correlationId,
       "CustomProcessesHost" -> "Digital",

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/EISConnector.scala
@@ -29,7 +29,7 @@ trait EISConnector {
     .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", ju.Locale.ENGLISH)
     .withZone(ZoneId.of("GMT"))
 
-  final def MDTPTracingHeaders(hc: HeaderCarrier): Seq[(String, String)] = {
+  final def mdtpTracingHeaders(hc: HeaderCarrier): Seq[(String, String)] = {
     Seq(
       hc.requestId.map(HeaderNames.xRequestId -> _.value),
       hc.sessionId.map(HeaderNames.xSessionId -> _.value)
@@ -37,7 +37,7 @@ trait EISConnector {
   }
 
   /** Headers required by the EIS API */
-  final def EISApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
+  final def eisApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
     Seq(
       "x-correlation-id"    -> correlationId,
       "CustomProcessesHost" -> "Digital",

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/FileTransferConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/FileTransferConnector.scala
@@ -37,9 +37,9 @@ class FileTransferConnector @Inject()(
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
-  val url = config.fileBaseUrl + config.fileBasePath
+  val url: String = config.fileBaseUrl + config.fileBasePath
 
-  final def transferFile(fileTransferRequest: FileTransferRequest, correlationId: String)(implicit
+  final def transferFile(fileTransferRequest: FileTransferRequest)(implicit
                                                                                           hc: HeaderCarrier,
                                                                                           ec: ExecutionContext
   ): Future[FileTransferResult] =

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/ClaimController.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/ClaimController.scala
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 class UUIDGenerator {
-  def uuid: String = ju.UUID.randomUUID().toString()
+  def uuid: String = ju.UUID.randomUUID().toString
 }
 
 @Singleton
@@ -49,144 +49,138 @@ class ClaimController @Inject()(
                                  val uuidGenerator: UUIDGenerator,
                                  val auditService: AuditService,
                                )
-                               (implicit ec: ExecutionContext) extends BackendController(cc) with AuthActions with ControllerHelper {
+                               (implicit ec: ExecutionContext) extends BackendController(cc) with AuthActions with ControllerHelper with WithCorrelationId {
 
   def submitClaim(): Action[JsValue] = Action(parse.json).async { implicit request =>
-    val correlationId = request.headers
-      .get("x-correlation-id")
-      .getOrElse(uuidGenerator.uuid)
+    withCorrelationId { correlationId: String =>
+      withAuthorised {
+        withPayload[CreateClaimRequest] { createCaseRequest =>
+          val eisCreateCaseRequest = EISCreateCaseRequest(
+            AcknowledgementReference = correlationId.replace("-", ""),
+            ApplicationType = "NDRC",
+            OriginatingSystem = "Digital",
+            Content = EISCreateCaseRequest.Content.from(createCaseRequest)
+          )
+          claimService.createClaim(eisCreateCaseRequest, correlationId).flatMap {
+            case success: EISCreateCaseSuccess =>
+              transferFilesToPega(success.CaseID, correlationId, createCaseRequest.uploadedFiles)
+                .flatMap { fileTransferResults =>
+                  val response = NDRCCaseResponse(
+                    correlationId = correlationId,
+                    result = Option(
+                      NDRCFileTransferResult(success.CaseID, LocalDateTime.now(), fileTransferResults)
+                    ))
+                  auditService
+                    .auditCreateCaseEvent(createCaseRequest)(response)
+                    .map(_ => Created(Json.toJson(response)))
+                }
 
-    withAuthorised {
-      withPayload[CreateClaimRequest] { createCaseRequest =>
-        val eisCreateCaseRequest = EISCreateCaseRequest(
-          AcknowledgementReference = correlationId.replace("-", ""),
-          ApplicationType = "NDRC",
-          OriginatingSystem = "Digital",
-          Content = EISCreateCaseRequest.Content.from(createCaseRequest)
-        )
-        claimService.createClaim(eisCreateCaseRequest, correlationId).flatMap {
-          case success: EISCreateCaseSuccess =>
-            transferFilesToPega(success.CaseID, correlationId, createCaseRequest.uploadedFiles)
-              .flatMap { fileTransferResults =>
-                val response = NDRCCaseResponse(
-                  correlationId = correlationId,
-                  result = Option(
-                    NDRCFileTransferResult(success.CaseID, LocalDateTime.now(), fileTransferResults)
-                  ))
-                auditService
-                  .auditCreateCaseEvent(createCaseRequest)(response)
-                  .map(_ => Created(Json.toJson(response)))
-              }
-
-          // when request to the upstream api returns an error
-          case error: EISCreateCaseError => {
+            // when request to the upstream api returns an error
+            case error: EISCreateCaseError =>
+              val response = NDRCCaseResponse(
+                correlationId = correlationId,
+                error = Some(
+                  ApiError(
+                    errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
+                    errorMessage = error.errorMessage
+                  )
+                )
+              )
+              auditService
+                .auditCreateCaseEvent(createCaseRequest)(response)
+                .map(_ => BadRequest(Json.toJson(response)))
+          }
+        } {
+          // when incoming request's payload validation fails
+          case (errorCode, errorMessage) =>
             val response = NDRCCaseResponse(
               correlationId = correlationId,
               error = Some(
-                ApiError(
-                  errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
-                  errorMessage = error.errorMessage
-                )
+                ApiError(errorCode, Some(errorMessage))
               )
             )
             auditService
-              .auditCreateCaseEvent(createCaseRequest)(response)
+              .auditCreateCaseErrorEvent(response)
               .map(_ => BadRequest(Json.toJson(response)))
-          }
         }
-      } {
-        // when incoming request's payload validation fails
-        case (errorCode, errorMessage) =>
+      }.recoverWith {
+        // last resort fallback when request processing fails
+        case e =>
           val response = NDRCCaseResponse(
             correlationId = correlationId,
             error = Some(
-              ApiError(errorCode, Some(errorMessage))
+              ApiError("500", Some(e.getMessage))
             )
           )
           auditService
             .auditCreateCaseErrorEvent(response)
-            .map(_ => BadRequest(Json.toJson(response)))
+            .map(_ => InternalServerError(Json.toJson(response)))
       }
-    }.recoverWith {
-      // last resort fallback when request processing fails
-      case e =>
-        val response = NDRCCaseResponse(
-          correlationId = correlationId,
-          error = Some(
-            ApiError("500", Some(e.getMessage()))
-          )
-        )
-        auditService
-          .auditCreateCaseErrorEvent(response)
-          .map(_ => InternalServerError(Json.toJson(response)))
     }
   }
 
   def submitAmendClaim(): Action[JsValue] = Action(parse.json).async { implicit request =>
-
-    val correlationId = request.headers
-      .get("x-correlation-id")
-      .getOrElse(uuidGenerator.uuid)
-
-    withAuthorised {
-      withPayload[AmendClaimRequest] { amendCaseRequest =>
-        val eisAmendCaseRequest = EISAmendCaseRequest(
-          AcknowledgementReference = correlationId.replace("-", ""),
-          ApplicationType = "NDRC",
-          OriginatingSystem = "Digital",
-          Content = EISAmendCaseRequest.Content.from(amendCaseRequest)
-        )
-        claimService.amendClaim(eisAmendCaseRequest, correlationId).flatMap {
-          case success: EISAmendCaseSuccess =>
-            transferFilesToPega(success.CaseID, correlationId, amendCaseRequest.uploadedFiles)
-              .flatMap { fileTransferResults =>
-                val response = NDRCCaseResponse(
-                  correlationId = correlationId,
-                  result = Option(
-                    NDRCFileTransferResult(success.CaseID, LocalDateTime.now(), fileTransferResults)
-                  ))
-                auditService.auditUpdateCaseEvent(amendCaseRequest)(response).map(_ =>
-                  Created(Json.toJson(response)))
-              }
-          // when request to the upstream api returns an error
-          case error: EISAmendCaseError =>
+    withCorrelationId { correlationId: String =>
+      withAuthorised {
+        withPayload[AmendClaimRequest] { amendCaseRequest =>
+          val eisAmendCaseRequest = EISAmendCaseRequest(
+            AcknowledgementReference = correlationId.replace("-", ""),
+            ApplicationType = "NDRC",
+            OriginatingSystem = "Digital",
+            Content = EISAmendCaseRequest.Content.from(amendCaseRequest)
+          )
+          claimService.amendClaim(eisAmendCaseRequest, correlationId).flatMap {
+            case success: EISAmendCaseSuccess =>
+              transferFilesToPega(success.CaseID, correlationId, amendCaseRequest.uploadedFiles)
+                .flatMap { fileTransferResults =>
+                  val response = NDRCCaseResponse(
+                    correlationId = correlationId,
+                    result = Option(
+                      NDRCFileTransferResult(success.CaseID, LocalDateTime.now(), fileTransferResults)
+                    ))
+                  auditService.auditUpdateCaseEvent(amendCaseRequest)(response).map(_ =>
+                    Created(Json.toJson(response)))
+                }
+            // when request to the upstream api returns an error
+            case error: EISAmendCaseError =>
+              val response = NDRCCaseResponse(
+                correlationId = correlationId,
+                error = Some(
+                  ApiError(
+                    errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
+                    errorMessage = error.errorMessage
+                  )
+                )
+              )
+              auditService.auditUpdateCaseEvent(amendCaseRequest)(response)
+                .map(_ => BadRequest(Json.toJson(response)))
+          }
+        } {
+          // when incoming request's payload validation fails
+          case (errorCode, errorMessage) =>
             val response = NDRCCaseResponse(
               correlationId = correlationId,
               error = Some(
-                ApiError(
-                  errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
-                  errorMessage = error.errorMessage
-                )
+                ApiError(errorCode, Some(errorMessage))
               )
             )
-            auditService.auditUpdateCaseEvent(amendCaseRequest)(response)
+            auditService
+              .auditUpdateCaseErrorEvent(response)
               .map(_ => BadRequest(Json.toJson(response)))
         }
-      } {
-        // when incoming request's payload validation fails
-        case (errorCode, errorMessage) =>
+      }.recoverWith {
+        // last resort fallback when request processing fails
+        case e =>
           val response = NDRCCaseResponse(
             correlationId = correlationId,
             error = Some(
-              ApiError(errorCode, Some(errorMessage))
+              ApiError("500", Some(e.getMessage))
             )
           )
           auditService
             .auditUpdateCaseErrorEvent(response)
-            .map(_ => BadRequest(Json.toJson(response)))
+            .map(_ => InternalServerError(Json.toJson(response)))
       }
-    }.recoverWith {
-      // last resort fallback when request processing fails
-      case e =>
-        val response = NDRCCaseResponse(
-          correlationId = correlationId,
-          error = Some(
-            ApiError("500", Some(e.getMessage()))
-          )
-        )
-        auditService
-          .auditUpdateCaseErrorEvent(response)
-          .map(_ => InternalServerError(Json.toJson(response)))
     }
   }
 
@@ -202,15 +196,15 @@ class ClaimController @Inject()(
             FileTransferRequest
               .fromUploadedFile(
                 caseReferenceNumber,
-                conversationId,
-                correlationId = uuidGenerator.uuid,
+                conversationId, // expect all file transfers to have the same conversation ID/x-request-id
+                correlationId = uuidGenerator.uuid, // expect a unique correlation ID per file transfer
                 applicationName = "NDRC",
                 batchSize = uploadedFiles.size,
                 batchCount = index + 1,
                 uploadedFile = file
               )
         }
-        .map(fileTransferConnector.transferFile(_, conversationId))
+        .map(fileTransferConnector.transferFile)
     )
   }
 }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/ClaimController.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/ClaimController.scala
@@ -18,8 +18,6 @@ package uk.gov.hmrc.nationaldutyrepaymentcenter.controllers
 
 
 import java.time.LocalDateTime
-import java.{util => ju}
-
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, ControllerComponents}
@@ -28,16 +26,11 @@ import uk.gov.hmrc.nationaldutyrepaymentcenter.connectors._
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.requests._
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.responses._
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.{FileTransferRequest, FileTransferResult, UploadedFile}
-import uk.gov.hmrc.nationaldutyrepaymentcenter.services.{AuditService, ClaimService}
+import uk.gov.hmrc.nationaldutyrepaymentcenter.services.{AuditService, ClaimService, UUIDGenerator}
 import uk.gov.hmrc.nationaldutyrepaymentcenter.wiring.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
-
-
-class UUIDGenerator {
-  def uuid: String = ju.UUID.randomUUID().toString
-}
 
 @Singleton
 class ClaimController @Inject()(
@@ -51,12 +44,15 @@ class ClaimController @Inject()(
                                )
                                (implicit ec: ExecutionContext) extends BackendController(cc) with AuthActions with ControllerHelper with WithCorrelationId {
 
+  private def acknowledgementReferenceFrom (correlationId: String): String =
+    correlationId.replace("-", "").takeRight(32)
+
   def submitClaim(): Action[JsValue] = Action(parse.json).async { implicit request =>
     withCorrelationId { correlationId: String =>
       withAuthorised {
         withPayload[CreateClaimRequest] { createCaseRequest =>
           val eisCreateCaseRequest = EISCreateCaseRequest(
-            AcknowledgementReference = correlationId.replace("-", ""),
+            AcknowledgementReference = acknowledgementReferenceFrom(correlationId),
             ApplicationType = "NDRC",
             OriginatingSystem = "Digital",
             Content = EISCreateCaseRequest.Content.from(createCaseRequest)
@@ -124,7 +120,7 @@ class ClaimController @Inject()(
       withAuthorised {
         withPayload[AmendClaimRequest] { amendCaseRequest =>
           val eisAmendCaseRequest = EISAmendCaseRequest(
-            AcknowledgementReference = correlationId.replace("-", ""),
+            AcknowledgementReference = acknowledgementReferenceFrom(correlationId),
             ApplicationType = "NDRC",
             OriginatingSystem = "Digital",
             Content = EISAmendCaseRequest.Content.from(amendCaseRequest)

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/WithCorrelationId.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/WithCorrelationId.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.nationaldutyrepaymentcenter.controllers
 import play.api.mvc.{Request, _}
 import play.api.libs.json.{JsNumber, JsString, Json}
 import play.api.mvc.Result
+import uk.gov.hmrc.nationaldutyrepaymentcenter.services.UUIDGenerator
 
 import scala.concurrent.Future
 
@@ -29,11 +30,12 @@ trait WithCorrelationId { self: Results =>
       "message"    -> JsString("Missing header x-correlation-id")
     )
   )
+  val uuidGenerator: UUIDGenerator
 
   protected def withCorrelationId(f: String => Future[Result])(implicit request: Request[_]): Future[Result] =
     request.headers.get("x-correlation-id") match {
       case Some(value) => f(value)
-      case None        => Future.successful(missingXCorrelationIdResponse)
+      case None        => f(uuidGenerator.uuid)
     }
 
 }

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/WithCorrelationId.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/controllers/WithCorrelationId.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationaldutyrepaymentcenter.controllers
+
+import play.api.mvc.{Request, _}
+import play.api.libs.json.{JsNumber, JsString, Json}
+import play.api.mvc.Result
+
+import scala.concurrent.Future
+
+trait WithCorrelationId { self: Results =>
+  val missingXCorrelationIdResponse: Result = BadRequest(
+    Json.obj(
+      "statusCode" -> JsNumber(BadRequest.header.status),
+      "message"    -> JsString("Missing header x-correlation-id")
+    )
+  )
+
+  protected def withCorrelationId(f: String => Future[Result])(implicit request: Request[_]): Future[Result] =
+    request.headers.get("x-correlation-id") match {
+      case Some(value) => f(value)
+      case None        => Future.successful(missingXCorrelationIdResponse)
+    }
+
+}

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/models/FileTransferRequest.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/models/FileTransferRequest.scala
@@ -29,10 +29,7 @@ case class FileTransferRequest(
                                               fileMimeType: String,
                                               batchSize: Int,
                                               batchCount: Int,
-                                              correlationId: Option[String] = None,
-                                              // private field, this value will be overwritten
-                                              // with x-request-id header value in the controller
-                                              requestId: Option[String] = None
+                                              correlationId: String
                                             )
 
 object FileTransferRequest {
@@ -57,7 +54,7 @@ object FileTransferRequest {
       fileMimeType = uploadedFile.fileMimeType,
       batchSize = batchSize,
       batchCount = batchCount,
-      correlationId = Some(correlationId)
+      correlationId = correlationId
     )
 
   implicit val formats: Format[FileTransferRequest] =

--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/services/UUIDGenerator.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/services/UUIDGenerator.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationaldutyrepaymentcenter.services
+
+class UUIDGenerator {
+  def uuid: String = java.util.UUID.randomUUID().toString
+}

--- a/it/nationaldutyrepaymentcenter/connectors/FileTransferConnectorISpec.scala
+++ b/it/nationaldutyrepaymentcenter/connectors/FileTransferConnectorISpec.scala
@@ -1,7 +1,5 @@
 package nationaldutyrepaymentcenter.connectors
 
-
-import nationaldutyrepaymentcenter.controllers.TestData
 import play.api.Application
 import nationaldutyrepaymentcenter.support.AppBaseISpec
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models._
@@ -21,7 +19,7 @@ class FileTransferConnectorISpec extends FileTransferConnectorISpecSetup with Fi
 
         val request = testRequest
         givenNdrcFileTransferSucceeds(request)
-        val result = await(connector.transferFile(request, correlationId))
+        val result = await(connector.transferFile(request))
         result.success shouldBe true
       }
     }
@@ -37,10 +35,10 @@ trait FileTransferConnectorISpecSetup extends AppBaseISpec with FileTransferStub
   lazy val connector: FileTransferConnector =
     app.injector.instanceOf[FileTransferConnector]
 
-  val correlationId = java.util.UUID.randomUUID().toString()
-  val conversationId = java.util.UUID.randomUUID().toString()
+  val correlationId: String = java.util.UUID.randomUUID().toString
+  val conversationId: String = java.util.UUID.randomUUID().toString
 
-  val testRequest = Json
+  val testRequest: FileTransferRequest = Json
     .parse(s"""{
               |"conversationId":"$conversationId",
               |"caseReferenceNumber":"Risk-123",

--- a/it/nationaldutyrepaymentcenter/controllers/NDRCAmendCaseISpec.scala
+++ b/it/nationaldutyrepaymentcenter/controllers/NDRCAmendCaseISpec.scala
@@ -5,20 +5,18 @@ import nationaldutyrepaymentcenter.support.{JsonMatchers, ServerBaseISpec}
 import org.mockito.Mockito.when
 import org.scalatest.MustMatchers.convertToAnyMustWrapper
 import org.scalatest.Suite
-import org.scalatest.mockito.MockitoSugar.mock
 import org.scalatestplus.play.ServerProvider
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
-import uk.gov.hmrc.nationaldutyrepaymentcenter.controllers.UUIDGenerator
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.AmendCaseResponseType.{FurtherInformation, SupportingDocuments}
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.requests.AmendClaimRequest
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.responses.NDRCCaseResponse
-import uk.gov.hmrc.nationaldutyrepaymentcenter.models.{AmendContent, FileTransferRequest, SendDocuments, UploadedFile}
-import uk.gov.hmrc.nationaldutyrepaymentcenter.services.NDRCAuditEvent
+import uk.gov.hmrc.nationaldutyrepaymentcenter.models.{AmendContent, FileTransferRequest, UploadedFile}
+import uk.gov.hmrc.nationaldutyrepaymentcenter.services.{NDRCAuditEvent, UUIDGenerator}
 
-import java.time.{Clock, LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{ZoneId, ZonedDateTime}
 import java.{util => ju}
 
 class NDRCAmendCaseISpec
@@ -49,7 +47,7 @@ class NDRCAmendCaseISpec
         "microservice.services.file-transfer.port" -> wireMockPort,
       )  .overrides(
         bind[Clock].toInstance(clock),
-        bind[UUIDGenerator].toInstance(uuideGeneratorMock))
+        bind[UUIDGenerator].toInstance(uuidGeneratorMock))
   }
 
   override lazy val app =  appBuilder.build()

--- a/it/nationaldutyrepaymentcenter/controllers/NDRCCreateCaseISpec.scala
+++ b/it/nationaldutyrepaymentcenter/controllers/NDRCCreateCaseISpec.scala
@@ -12,11 +12,10 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
-import uk.gov.hmrc.nationaldutyrepaymentcenter.controllers.UUIDGenerator
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.requests.CreateClaimRequest
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.responses.NDRCCaseResponse
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.{Address, BankDetails, DocumentList, DutyTypeTaxDetails, _}
-import uk.gov.hmrc.nationaldutyrepaymentcenter.services.{AuditService, NDRCAuditEvent}
+import uk.gov.hmrc.nationaldutyrepaymentcenter.services.{AuditService, NDRCAuditEvent, UUIDGenerator}
 
 import java.time.{Clock, Instant, LocalDate, LocalDateTime, ZoneId, ZonedDateTime}
 import java.{util => ju}
@@ -45,7 +44,7 @@ class NDRCCreateCaseISpec
         "microservice.services.file-transfer.port" -> wireMockPort,
       )  .overrides(
       bind[Clock].toInstance(clock),
-      bind[UUIDGenerator].toInstance(uuideGeneratorMock))
+      bind[UUIDGenerator].toInstance(uuidGeneratorMock))
   }
 
   override lazy val app =  appBuilder.build()
@@ -53,13 +52,13 @@ class NDRCCreateCaseISpec
   val dateTime = LocalDateTime.now()
 
   val wsClient = app.injector.instanceOf[WSClient]
-  val uuidGenerator = app.injector.instanceOf[UUIDGenerator]
+  val uuidGenerator: UUIDGenerator = app.injector.instanceOf[UUIDGenerator]
 
   "ClaimController" when {
     "POST /create-case" should {
       "return 201 with CaseID as a result if successful PEGA API call" in {
 
-        val correlationId = ju.UUID.randomUUID().toString()
+        val correlationId = ju.UUID.randomUUID().toString
         when(uuidGenerator.uuid).thenReturn(correlationId)
 
         val uf = TestData.uploadedFiles(wireMockBaseUrlAsString).head

--- a/it/nationaldutyrepaymentcenter/stubs/FileTransferStubs.scala
+++ b/it/nationaldutyrepaymentcenter/stubs/FileTransferStubs.scala
@@ -19,7 +19,7 @@ trait FileTransferStubs {
         .willReturn(
           aResponse()
             .withStatus(200)
-            .withBody(Json.toJson(FileTransferResult(fileTransferRequest.correlationId.get, true, 200, time)).toString())
+            .withBody(Json.toJson(FileTransferResult(fileTransferRequest.correlationId, success = true, 200, time)).toString())
         )
     )
   }
@@ -34,7 +34,7 @@ trait FileTransferStubs {
         .willReturn(
           aResponse()
             .withStatus(409)
-            .withBody(Json.toJson(FileTransferResult(fileTransferRequest.correlationId.get, true, 409, time)).toString())
+            .withBody(Json.toJson(FileTransferResult(fileTransferRequest.correlationId, success = true, 409, time)).toString())
         )
     )
   }

--- a/it/nationaldutyrepaymentcenter/support/TestApplication.scala
+++ b/it/nationaldutyrepaymentcenter/support/TestApplication.scala
@@ -4,7 +4,7 @@ import org.scalatest.mockito.MockitoSugar.mock
 import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.nationaldutyrepaymentcenter.controllers.UUIDGenerator
+import uk.gov.hmrc.nationaldutyrepaymentcenter.services.UUIDGenerator
 
 import java.time.{Clock, Instant, ZoneId}
 
@@ -12,7 +12,7 @@ trait TestApplication {
   _: BaseISpec =>
 
   override implicit lazy val app: Application = appBuilder.build()
-  val uuideGeneratorMock = mock[UUIDGenerator]
+  val uuidGeneratorMock: UUIDGenerator = mock[UUIDGenerator]
   val clock: Clock = Clock.fixed(Instant.parse("2020-09-09T10:15:30.00Z"), ZoneId.of("UTC"))
 
   protected def appBuilder: GuiceApplicationBuilder =
@@ -31,5 +31,5 @@ trait TestApplication {
         "microservice.services.file-transfer.port" -> wireMockPort,
       )  .overrides(
       bind[Clock].toInstance(clock),
-      bind[UUIDGenerator].toInstance(uuideGeneratorMock))
+      bind[UUIDGenerator].toInstance(uuidGeneratorMock))
 }


### PR DESCRIPTION
Mandates that incoming amend/create requests specify an `X-Correlation-ID` header
 - pass this on as the `x-correlation-id` header to EIS
 - pass this on as the `conversation-id` header to File Transmission Synchronous
 
 Also passes x-request-id and x-session-id headers to EIS 
 
Note this is dependent on https://github.com/hmrc/national-duty-repayment-center-frontend/pull/405/files being merged/deployed first (as an `x-correlation-id` header is now required on the incoming request from the FE)