### PR TITLE
DDCYLS-472: Moved error handling out of ReadSuccessOrFailure.scala, a…

### DIFF
--- a/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationaldutyrepaymentcenter/connectors/AmendCaseConnector.scala
@@ -20,6 +20,7 @@ import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import com.google.inject.Inject
 import com.kenshoo.play.metrics.Metrics
+import play.api.Logger
 import play.api.libs.json.Writes
 import uk.gov.hmrc.http.{HeaderCarrier, _}
 import uk.gov.hmrc.nationaldutyrepaymentcenter.models.requests.EISAmendCaseRequest
@@ -36,11 +37,17 @@ class AmendCaseConnector @Inject()(
 )(implicit ec: ExecutionContext)
   extends ReadSuccessOrFailure[EISAmendCaseResponse, EISAmendCaseSuccess, EISAmendCaseError](
     EISAmendCaseError.fromStatusAndMessage
-  ) with EISConnector with HttpAPIMonitor with Retry {
+  ) with EISConnector
+    with HttpAPIMonitor
+    with Retry {
+
+  lazy private val logger = Logger(getClass)
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
   val url: String = config.eisBaseUrl + config.eisAmendCaseApiPath
+
+  val serviceName: String = "ConsumedAPI-eis-pega-amend-case-api-POST"
 
   def submitAmendClaim(request: EISAmendCaseRequest, correlationId: String)(implicit
     hc: HeaderCarrier
@@ -50,7 +57,7 @@ class AmendCaseConnector @Inject()(
       EISAmendCaseResponse.errorMessage,
       EISAmendCaseResponse.delayInterval
     ) {
-      monitor(s"ConsumedAPI-eis-pega-amend-case-api-POST") {
+      monitor(serviceName) {
         http.POST[EISAmendCaseRequest, EISAmendCaseResponse](
           url,
           request,
@@ -62,6 +69,13 @@ class AmendCaseConnector @Inject()(
           implicitly[ExecutionContext]
         )
       }
+    } recoverWith {
+      case e: GatewayTimeoutException =>
+        logger.error(s"$serviceName to $url failed with status: ${e.responseCode}")
+        throw new GatewayTimeoutException(e.getMessage)
+      case e =>
+        logger.error(s"$serviceName to $url failed with unexpected response")
+        throw new Exception(e.getMessage)
     }
 
 }

--- a/it/nationaldutyrepaymentcenter/stubs/AmendCaseStubs.scala
+++ b/it/nationaldutyrepaymentcenter/stubs/AmendCaseStubs.scala
@@ -1,6 +1,7 @@
 package nationaldutyrepaymentcenter.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import nationaldutyrepaymentcenter.support.WireMockSupport
 import org.scalatest.concurrent.Eventually.eventually
@@ -17,7 +18,17 @@ trait AmendCaseStubs {
         urlEqualTo(UPDATE_CASE_URL)
       ).willReturn(
         aResponse()
-          .withStatus(499)
+          .withFixedDelay(25000)
+      )
+    )
+
+  def givenEISCallFailsUnexpectedly(): Unit =
+    stubFor(
+      post(
+        urlEqualTo(UPDATE_CASE_URL)
+      ).willReturn(
+        aResponse()
+          .withFault(Fault.CONNECTION_RESET_BY_PEER)
       )
     )
 

--- a/it/nationaldutyrepaymentcenter/stubs/CreateCaseStubs.scala
+++ b/it/nationaldutyrepaymentcenter/stubs/CreateCaseStubs.scala
@@ -1,6 +1,7 @@
 package nationaldutyrepaymentcenter.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import nationaldutyrepaymentcenter.support.WireMockSupport
 import play.mvc.Http.MimeTypes
@@ -16,7 +17,17 @@ trait CreateCaseStubs {
         urlEqualTo(CREATE_CASE_URL)
       ).willReturn(
         aResponse()
-          .withStatus(499)
+          .withFixedDelay(25000)
+      )
+    )
+
+  def givenEISCallFailsUnexpectedly(): Unit =
+    stubFor(
+      post(
+        urlEqualTo(CREATE_CASE_URL)
+      ).willReturn(
+        aResponse()
+          .withFault(Fault.CONNECTION_RESET_BY_PEER)
       )
     )
 


### PR DESCRIPTION
…s it will not be run if the request fails, and itto recoverWith in the connector